### PR TITLE
Countries

### DIFF
--- a/src/actions/countryActions.js
+++ b/src/actions/countryActions.js
@@ -1,0 +1,12 @@
+import { fetchCountries } from "../util/country_api_util";
+export const RECEIVE_COUNTRIES = "RECEIVE_COUNTRIES";
+
+export const receiveCountries = ({ countries }) => ({
+  type: RECEIVE_COUNTRIES,
+  countries
+});
+
+export const fetchAllCountries = () => async dispatch => {
+  const payload = await fetchCountries();
+  dispatch(receiveCountries(payload));
+};

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -4,21 +4,25 @@ import { connect } from "react-redux";
 import { Switch, BrowserRouter, Route } from "react-router-dom";
 import { AuthRoute, ProtectedRoute } from "../util/route_util";
 import { authenticateUser, fetchCurrentUser } from "../actions/authActions";
+import { fetchAllCountries } from "../actions/countryActions";
 import Splash from "./splash/splash";
 import ScoresheetsContainer from "./scoresheets/scoresheets";
 import UserProfile from "./userProfile/userProfile";
 import "./App.css";
-import ContestShow from './contests/contestShow'
+import ContestShow from "./contests/contestShow";
 
 class App extends Component {
   static propTypes = {
     authenticateUser: PropTypes.func.isRequired,
-    fetchCurrentUser: PropTypes.func.isRequired
+    fetchCurrentUser: PropTypes.func.isRequired,
+    fetchAllCountries: PropTypes.func.isRequired
   };
 
   componentDidMount() {
     if (localStorage.getItem("token")) {
       this.props.fetchCurrentUser(localStorage.getItem("token"));
+    } else {
+      this.props.fetchAllCountries();
     }
   }
 
@@ -40,7 +44,8 @@ class App extends Component {
 
 const mapDispatchToProps = dispatch => ({
   authenticateUser: socialToken => dispatch(authenticateUser(socialToken)),
-  fetchCurrentUser: token => dispatch(fetchCurrentUser(token))
+  fetchCurrentUser: token => dispatch(fetchCurrentUser(token)),
+  fetchAllCountries: () => dispatch(fetchAllCountries())
 });
 
 export default connect(null, mapDispatchToProps)(App);

--- a/src/reducers/countriesReducer.js
+++ b/src/reducers/countriesReducer.js
@@ -1,5 +1,5 @@
 import merge from "lodash/merge";
-import { RECEIVE_COUNTRIES } from "../actions/contest_actions";
+import { RECEIVE_COUNTRIES } from "../actions/countryActions";
 import { RECEIVE_CURRENT_USER } from "../actions/authActions";
 
 const countriesReducer = (state = {}, action) => {

--- a/src/reducers/countriesReducer.js
+++ b/src/reducers/countriesReducer.js
@@ -1,0 +1,18 @@
+import merge from "lodash/merge";
+import { RECEIVE_COUNTRIES } from "../actions/contest_actions";
+import { RECEIVE_CURRENT_USER } from "../actions/authActions";
+
+const countriesReducer = (state = {}, action) => {
+  switch (action.type) {
+    case RECEIVE_COUNTRIES:
+      return action.countries;
+    case RECEIVE_CURRENT_USER:
+      if (action.payload.countries) {
+        return action.payload.countries;
+      }
+    default:
+      return merge({}, state);
+  }
+};
+
+export default countriesReducer;

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -4,11 +4,13 @@ import scoresheets from "./scoresheetReducer";
 import contests from "./contests_reducer";
 import users from "./usersReducer";
 import entries from "./entries_reducers";
+import countries from "./countriesReducer";
 
 export default combineReducers({
   auth,
   users,
   scoresheets,
   contests,
-  entries
+  entries,
+  countries
 });

--- a/src/util/country_api_util.js
+++ b/src/util/country_api_util.js
@@ -1,0 +1,9 @@
+import { APIUrl } from "./constants";
+
+export const fetchCountries = async () => {
+  const response = await fetch(`${APIUrl}/countries`, {
+    method: "GET"
+  });
+  const payload = await response.json();
+  return payload;
+};


### PR DESCRIPTION
Ian and I discussed last night that we'll basically always need countries in a bunch of different places. So we could end up in a situation where we are just tagging countries along in the response to multiple requests. Instead, we talked about just fetching countries when the app loads so that we always have them in state. Now, when the app loads, we see if somebody is logged in (is there a token in localstorage) and if so, we go get the current user info like we were doing before only now we also get all the countries too. If there isn't somebody logged in, we just go get all the country data. I think this will save us headache down the road by knowing we will just always have countries available on the frontend. 