### PR TITLE
Add basic entry show page with youtube embedding

### DIFF
--- a/src/actions/entryActions.js
+++ b/src/actions/entryActions.js
@@ -1,0 +1,13 @@
+import * as EventAPIUtil from "../util/entry_api_util";
+
+export const RECEIVE_ENTRY = "RECEIVE_ENTRY";
+
+export const receiveEntry = payload => ({
+  type: RECEIVE_ENTRY,
+  payload
+});
+
+export const fetchEntry = entryId => async dispatch => {
+  const payload = await EventAPIUtil.fetchEntry(entryId);
+  dispatch(receiveEntry(payload));
+};

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -10,6 +10,7 @@ import ScoresheetsContainer from "./scoresheets/scoresheets";
 import UserProfile from "./userProfile/userProfile";
 import "./App.css";
 import ContestShow from "./contests/contestShow";
+import EntryShow from "./entries/entryShow";
 
 class App extends Component {
   static propTypes = {
@@ -34,6 +35,7 @@ class App extends Component {
             <Route exact path="/scoresheets" component={ScoresheetsContainer} />
             <Route exact path="/users/:id" component={UserProfile} />
             <Route exact path="/contests/:year" component={ContestShow} />
+            <Route exact path="/entries/:id" component={EntryShow} />
             <AuthRoute exact path="/" component={Splash} />
           </Switch>
         </main>

--- a/src/components/contests/contestShow.jsx
+++ b/src/components/contests/contestShow.jsx
@@ -15,14 +15,18 @@ class ContestShow extends React.Component {
   }
 
   render() {
-    const { contest, entries } = this.props;
+    const { contest, entries, countries } = this.props;
     return (
       <main>
         <div>EuroVision Song Contest {contest.year}</div>
         <ul>
           {entries.map(entry => {
+            const flag_url = countries[entry.country_id]
+              ? countries[entry.country_id].flag_url
+              : "";
             return (
               <li>
+                <img src={flag_url} />
                 {entry.song_title}, {entry.artist}
               </li>
             );
@@ -46,12 +50,13 @@ ContestShow.defaultProps = {
 };
 
 const mapStateToProps = (state, ownProps) => {
+  const { countries } = state;
   const year = ownProps.match.params.year;
   const contest = state.contests[year] || { year: "LOADING", entry_ids: [] };
   const entries = contest.entry_ids.map(id => {
     return state.entries[id];
   });
-  return { year, contest, entries };
+  return { year, contest, entries, countries };
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/components/entries/entryShow.jsx
+++ b/src/components/entries/entryShow.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import { fetchEntry } from "../../actions/entryActions";
+import YouTube from "../video/YouTube";
+
+class EntryShow extends React.Component {
+  componentDidMount() {
+    if (this.props.entry.song_title === "LOADING") {
+      this.props.fetchEntry(this.props.entryId);
+    }
+  }
+
+  render() {
+    
+    const { entry, country, contest } = this.props;
+    debugger
+    if (entry.song_title === "LOADING") {
+      return <p>Spinner Goes Here</p>;
+    } else {
+      return (
+        <section>
+          <h1>
+            {entry.song_title}, {entry.artist}
+          </h1>
+          <h2>{country.name}, {contest.year}</h2>
+          <h3>Ranking: {entry.final_ranking}</h3>
+          <h3>Score: {entry.final_score}</h3>
+          <YouTube url={entry.video_url} />
+        </section>
+      );
+    }
+  }
+}
+
+EntryShow.propTypes = {
+  entryId: PropTypes.string.isRequired,
+  entry: PropTypes.object,
+  country: PropTypes.object,
+  contest: PropTypes.object
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const entryId = ownProps.match.params.id;
+  const entry = state.entries[entryId] || { song_title: "LOADING" };
+  debugger
+  const contest = state.contests[entry.contest_id] || { year: "LOADING"}
+  const country = state.countries[entry.country_id] || {
+    name: "LOADING",
+    flag_url: "/defaultflag"
+  };
+
+  return {
+    entryId,
+    entry,
+    country,
+    contest
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  fetchEntry: id => dispatch(fetchEntry(id))
+});
+
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(EntryShow)
+);

--- a/src/components/entries/entryShow.jsx
+++ b/src/components/entries/entryShow.jsx
@@ -13,9 +13,8 @@ class EntryShow extends React.Component {
   }
 
   render() {
-    
+
     const { entry, country, contest } = this.props;
-    debugger
     if (entry.song_title === "LOADING") {
       return <p>Spinner Goes Here</p>;
     } else {
@@ -44,7 +43,6 @@ EntryShow.propTypes = {
 const mapStateToProps = (state, ownProps) => {
   const entryId = ownProps.match.params.id;
   const entry = state.entries[entryId] || { song_title: "LOADING" };
-  debugger
   const contest = state.contests[entry.contest_id] || { year: "LOADING"}
   const country = state.countries[entry.country_id] || {
     name: "LOADING",

--- a/src/components/video/YouTube.jsx
+++ b/src/components/video/YouTube.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class YouTube extends React.Component {
+  render() {
+    let { url, width, height } = this.props;
+    if (url.includes("http")) {
+      url = url.split("v=")[1];
+    }
+    debugger;
+    return (
+      <iframe
+        width="560"
+        height="315"
+        src={`https://www.youtube.com/embed/${url}?rel=0&amp;showinfo=0`}
+        frameborder="0"
+        allow="autoplay; encrypted-media"
+        allowfullscreen
+      />
+    );
+  }
+}
+// <iframe
+//   width={this.props.width}
+//   height={this.props.height}
+//   src={`https://www.youtube.com/embed/${this.props.url}?rel=0&amp;showinfo=0`}
+//   frameborder="0"
+//   allow="encrypted-media"
+//   allowFullScreen
+//   />
+
+YouTube.propTypes = {
+  url: PropTypes.string,
+  width: PropTypes.string,
+  height: PropTypes.string
+};
+
+YouTube.defaultProps = {
+  url: "",
+  width: "560",
+  height: "315"
+};
+
+export default YouTube;

--- a/src/components/video/YouTube.jsx
+++ b/src/components/video/YouTube.jsx
@@ -7,7 +7,7 @@ class YouTube extends React.Component {
     if (url.includes("http")) {
       url = url.split("v=")[1];
     }
-     return (
+    return (
       <iframe
         width={width}
         height={height}

--- a/src/components/video/YouTube.jsx
+++ b/src/components/video/YouTube.jsx
@@ -7,11 +7,10 @@ class YouTube extends React.Component {
     if (url.includes("http")) {
       url = url.split("v=")[1];
     }
-    debugger;
-    return (
+     return (
       <iframe
-        width="560"
-        height="315"
+        width={width}
+        height={height}
         src={`https://www.youtube.com/embed/${url}?rel=0&amp;showinfo=0`}
         frameborder="0"
         allow="autoplay; encrypted-media"
@@ -20,14 +19,6 @@ class YouTube extends React.Component {
     );
   }
 }
-// <iframe
-//   width={this.props.width}
-//   height={this.props.height}
-//   src={`https://www.youtube.com/embed/${this.props.url}?rel=0&amp;showinfo=0`}
-//   frameborder="0"
-//   allow="encrypted-media"
-//   allowFullScreen
-//   />
 
 YouTube.propTypes = {
   url: PropTypes.string,

--- a/src/reducers/contests_reducer.js
+++ b/src/reducers/contests_reducer.js
@@ -1,5 +1,6 @@
 import merge from "lodash/merge";
 import { RECEIVE_CONTEST } from "../actions/contest_actions";
+import { RECEIVE_ENTRY } from "../actions/entryActions";
 
 const contestsReducer = (state = {}, action) => {
   let newState = merge({}, state);
@@ -8,6 +9,10 @@ const contestsReducer = (state = {}, action) => {
       newState = merge({}, newState, {
         [action.payload.contest.year]: action.payload.contest
       });
+      return newState;
+    case RECEIVE_ENTRY:
+      const { contest } = action.payload;
+      newState[contest.id] = contest;
       return newState;
     default:
       return newState;

--- a/src/reducers/entries_reducers.js
+++ b/src/reducers/entries_reducers.js
@@ -1,11 +1,16 @@
 import merge from "lodash/merge";
 import { RECEIVE_CONTEST } from "../actions/contest_actions";
+import { RECEIVE_ENTRY } from "../actions/entryActions";
 
 const entriesReducer = (state = {}, action) => {
   let newState = merge({}, state);
   switch (action.type) {
     case RECEIVE_CONTEST:
       newState = merge({}, state, action.payload.entries);
+      return newState;
+    case RECEIVE_ENTRY:
+      const { entry } = action.payload;
+      newState[entry.id] = entry;
       return newState;
     default:
       return newState;

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -2,8 +2,6 @@ export const backendUrl = "http://localhost:3000/";
 export const authUrl = "http://localhost:3000/auth";
 // this for requests to backend
 
-export const APIUrl = "http://localhost:3000/";
-
 export const authHeaders = () => {
   if (localStorage.getItem('token')) {
     return {

--- a/src/util/contest_api_util.js
+++ b/src/util/contest_api_util.js
@@ -1,7 +1,7 @@
-import { APIUrl } from "./constants";
+import { backendUrl } from "./constants";
 
 export const fetchContest = async year => {
-  const response = await fetch(`${APIUrl}/contests/${year}`, {
+  const response = await fetch(`${backendUrl}/contests/${year}`, {
     method: "GET"
   });
   const payload = await response.json();

--- a/src/util/country_api_util.js
+++ b/src/util/country_api_util.js
@@ -1,7 +1,7 @@
-import { APIUrl } from "./constants";
+import { backendUrl } from "./constants";
 
 export const fetchCountries = async () => {
-  const response = await fetch(`${APIUrl}/countries`, {
+  const response = await fetch(`${backendUrl}/countries`, {
     method: "GET"
   });
   const payload = await response.json();

--- a/src/util/entry_api_util.js
+++ b/src/util/entry_api_util.js
@@ -1,0 +1,10 @@
+import { backendUrl } from './constants';
+
+export const fetchEntry = async entryId => {
+  const response = await fetch(
+    `${backendUrl}entries/${entryId}`,
+    { method: 'GET' }
+  );
+  const payload = await response.json();
+  return payload;
+};

--- a/src/util/user_api_util.js
+++ b/src/util/user_api_util.js
@@ -1,7 +1,7 @@
-import { APIUrl, authHeaders } from "./constants";
+import { backendUrl, authHeaders } from "./constants";
 
 export const fetchUser = async userId => {
-  const response = await fetch(`${APIUrl}/users/${userId}`, {
+  const response = await fetch(`${backendUrl}/users/${userId}`, {
     method: "GET"
   });
   const payload = await response.json();


### PR DESCRIPTION
Base Entry Show page. The main thing I wanted to make sure I knew how to do is the YouTube embedding.

I abstracted the YouTube video into its own component, eventually so that we can have more customization over size of video, various options, etc. for each video. I realized that for the seed data I put in the wrong links, really, and that I'll need to go back and update the seeds soon so that they just have the video id (which is just a hash of random characters assigned by YouTube) and not a url. 