### PR TITLE
Scoresheetsindex

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -33,6 +33,7 @@ body {
   font-family: sans-serif;
   background: linear-gradient(to bottom right, #5FBEDE, #002659);
   /*sample colors*/
+  min-height: 100vw;
   height: 100%;
 }
 

--- a/src/components/scoresheets/my_scoresheets_container.jsx
+++ b/src/components/scoresheets/my_scoresheets_container.jsx
@@ -1,19 +1,25 @@
-import { connect } from 'react-redux';
-import Scoresheets from './scoresheets';
-import { fetchScoresheet, fetchScoresheets, removeScoresheet } from '../../actions/scoresheet_actions';
+import { connect } from "react-redux";
+import Scoresheets from "./scoresheets";
+import {
+  fetchScoresheet,
+  fetchScoresheets,
+  removeScoresheet
+} from "../../actions/scoresheet_actions";
 
-const mapStateToProps = (state) => {
-  const scoresheets = state.auth.currentUser ? state.auth.currentUser.scoresheet_ids : [];
+const mapStateToProps = state => {
+  const scoresheets = state.auth.currentUser
+    ? state.auth.currentUser.scoresheet_ids
+    : [];
   return {
-    scoresheets: scoresheets.map( (id) => {
+    scoresheets: scoresheets.map(id => {
       return state.scoresheets[id];
     }),
-    user: state.auth.currentUser,
+    user: state.auth.currentUser
   };
 };
 
-const mapDispatchToProps = (dispatch) => ({
-  fetchScoresheets: (userId) => dispatch(fetchScoresheets(userId)),
+const mapDispatchToProps = dispatch => ({
+  fetchScoresheets: userId => dispatch(fetchScoresheets(userId))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Scoresheets);

--- a/src/components/scoresheets/scoresheet.jsx
+++ b/src/components/scoresheets/scoresheet.jsx
@@ -15,6 +15,7 @@ const mapStateToProps = (state, ownProps) => {
   scoresheet.entry_ids.forEach( (id) => {
     entries[id] = state.entries[id];
   });
+  debugger
   const scorings = scoresheet.scoring_ids.map( (id) => {
     return state.scorings[id];
   }) || [];
@@ -40,7 +41,6 @@ class Scoresheet extends React.Component {
 
   createEntries() {
     if (this.props.scoresheet.id !== "LOADING") {
-
       this.props.scorings.forEach( (scoring) => {
         if (scoring) {
           this.props.entries[scoring.entry_id].scoring = scoring;
@@ -65,6 +65,7 @@ class Scoresheet extends React.Component {
   render () {
     return(
       <section className="section--scoresheet-main">
+        <p>{ this.props.scoresheet.name }</p>
         <table className="table--scoresheet-headers">
           <tbody>
             <tr className="tr--scoresheet-header-row">

--- a/src/components/scoresheets/scoresheet.jsx
+++ b/src/components/scoresheets/scoresheet.jsx
@@ -1,37 +1,48 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { fetchScoresheet, removeScoresheet } from '../../actions/scoresheet_actions';
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import {
+  fetchScoresheet,
+  removeScoresheet
+} from "../../actions/scoresheet_actions";
 import merge from "lodash/merge";
-import ScoresheetEntry from './scoresheet_entry.jsx';
-import './scoresheet.css';
+import ScoresheetEntry from "./scoresheet_entry.jsx";
+import "./scoresheet.css";
 
 //=========================================
 // props / actions
 
 const mapStateToProps = (state, ownProps) => {
-  const scoresheet = ownProps.scoresheet || { id: 'LOADING', entry_ids: [], scoring_ids: [] };
+  const scoresheet = ownProps.scoresheet || {
+    id: "LOADING",
+    entry_ids: [],
+    scoring_ids: []
+  };
   const entries = {};
-  scoresheet.entry_ids.forEach( (id) => {
+  scoresheet.entry_ids.forEach(id => {
     entries[id] = state.entries[id];
   });
-  const scorings = scoresheet.scoring_ids.map( (id) => {
-    return state.scorings[id];
+  const scorings = {};
+
+  scoresheet.scoring_ids.forEach(id => {
+    if (state.scorings[id]) {
+      const newScoring = state.scorings[id];
+      scorings[newScoring.entry_id] = newScoring;
+    }
   }) || [];
   const countries = state.countries;
   return { scoresheet, entries, scorings, countries };
 };
 
-const mapDispatchToProps = (dispatch) => ({
-  fetchScoresheet: (scoresheetId) => dispatch(fetchScoresheet(scoresheetId)),
-  removeScoresheet: (scoresheetId) => dispatch(removeScoresheet(scoresheetId)),
+const mapDispatchToProps = dispatch => ({
+  fetchScoresheet: scoresheetId => dispatch(fetchScoresheet(scoresheetId)),
+  removeScoresheet: scoresheetId => dispatch(removeScoresheet(scoresheetId))
 });
 
 //=========================================
 // component
 
 class Scoresheet extends React.Component {
-
   componentWillReceiveProps(newProps) {
     if (newProps.scoresheet.id !== this.props.scoresheet.id) {
       this.props.fetchScoresheet(newProps.scoresheet.id);
@@ -40,36 +51,34 @@ class Scoresheet extends React.Component {
 
   createEntries() {
     if (this.props.scoresheet.id !== "LOADING") {
-      this.props.scorings.forEach( (scoring) => {
-        if (scoring) {
-          this.props.entries[scoring.entry_id].scoring = scoring;
-        }
-      });
-
       let entryComponents = Object.values(this.props.entries);
 
-      return entryComponents.map( (entry) => {
+      return entryComponents.map(entry => {
         if (entry) {
+          const scoring = this.props.scorings[entry.id];
           return (
-            <li key={entry.id}><ScoresheetEntry entry={entry}
+            <li key={entry.id}>
+              <ScoresheetEntry
+                entry={entry}
+                scoring={scoring}
                 country={this.props.countries[entry.country_id]}
-                scoresheetId={this.props.scoresheet.id}/>
+                scoresheetId={this.props.scoresheet.id}
+              />
             </li>
           );
         } else {
           return null;
         }
       });
-
     } else {
       return <li>Loading...</li>;
     }
   }
 
-  render () {
-    return(
+  render() {
+    return (
       <section className="section--scoresheet-main">
-        <p>{ this.props.scoresheet.name }</p>
+        <p>{this.props.scoresheet.name}</p>
         <table className="table--scoresheet-headers">
           <tbody>
             <tr className="tr--scoresheet-header-row">
@@ -79,13 +88,10 @@ class Scoresheet extends React.Component {
             </tr>
           </tbody>
         </table>
-        <ul>
-          { this.createEntries() }
-        </ul>
+        <ul>{this.createEntries()}</ul>
       </section>
     );
   }
-
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Scoresheet);

--- a/src/components/scoresheets/scoresheet.jsx
+++ b/src/components/scoresheets/scoresheet.jsx
@@ -50,7 +50,12 @@ class Scoresheet extends React.Component {
 
       return entryComponents.map( (entry) => {
         if (entry) {
-          return <li key={entry.id}><ScoresheetEntry entry={entry} country={this.props.countries[entry.country_id]} /></li>;
+          return (
+            <li key={entry.id}><ScoresheetEntry entry={entry}
+                country={this.props.countries[entry.country_id]}
+                scoresheetId={this.props.scoresheet.id}/>
+            </li>
+          );
         } else {
           return null;
         }

--- a/src/components/scoresheets/scoresheet.jsx
+++ b/src/components/scoresheets/scoresheet.jsx
@@ -15,7 +15,6 @@ const mapStateToProps = (state, ownProps) => {
   scoresheet.entry_ids.forEach( (id) => {
     entries[id] = state.entries[id];
   });
-  debugger
   const scorings = scoresheet.scoring_ids.map( (id) => {
     return state.scorings[id];
   }) || [];

--- a/src/components/scoresheets/scoresheet_entry.css
+++ b/src/components/scoresheets/scoresheet_entry.css
@@ -6,6 +6,19 @@ section[class^='section--entry_parent_'] {
   display: flex;
 }
 
+section[class^='section--entry_parent_'] img {
+  height: 20px;
+  width: auto;
+}
+
+#li--entry_country {
+  display: flex;
+  box-sizing: border-box;
+  width: 200px;
+  justify-content: space-between;
+  padding-right: 60px;
+}
+
 section[class^='section--entry_parent_'] li {
   display: flex;
   margin: 0 10px;

--- a/src/components/scoresheets/scoresheet_entry.jsx
+++ b/src/components/scoresheets/scoresheet_entry.jsx
@@ -1,25 +1,17 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import YouTube from '../video/YouTube';
-import './scoresheet_entry.css';
-
-//=========================================
-// props / actions
-
-const mapStateToProps = (state, ownProps) => {
-  return {
-    entry: ownProps.entry,
-    scoring: ownProps.entry.scoring,
-    country: ownProps.country,
-  };
-};
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import YouTube from "../video/YouTube";
+import "./scoresheet_entry.css";
 
 //=========================================
 // component
 
 class ScoresheetEntry extends React.Component {
   static defaultProps = {
+    entry: {
+      id: null
+    },
     scoring: {
       id: null,
       bonus_comment: "",
@@ -28,44 +20,22 @@ class ScoresheetEntry extends React.Component {
       costume_score: "",
       dance_score: "",
       score_note: "",
-      song_score: "",
+      song_score: ""
     }
-  }
+  };
 
   constructor(props) {
     super(props);
-    this.state = { renderVideo: false };
-    this.entry = this.props.entry;
-    this.country = this.props.country;
-    this.state = { scoring: this.props.scoring };
-    this.state.scoring.entry_id = this.props.entry.id || null;
-    this.state.scoring.scoresheet_id = this.props.scoresheetId || null;
-    this.scoring = this.state.scoring;
+    this.state = { renderScoreSection: false, scoring: this.props.scoring };
   }
 
   toggleScoreShow() {
-    let el = document.getElementById(`section--entry_score_${this.entry.id}`);
-    if (el.classList.contains("hidden")) {
-      el.classList.remove("hidden");
-      this.setState( { renderVideo: true } );
-    } else {
-      el.classList.add("hidden");
-      this.setState( { renderVideo: false } );
-    }
-  }
-
-  renderVideo() {
-    if (this.state.renderVideo === true) {
-        return(
-          <YouTube url={this.entry.video_url} />
-        );
-    } else {
-      return null;
-    }
+    const newValue = this.state.renderScoreSection ? false : true;
+    this.setState({ renderScoreSection: newValue });
   }
 
   handleChange(field) {
-    return (e) => {
+    return e => {
       let newScore = this.state.scoring;
       if (field === "bonus_comment" || field === "score_note") {
         newScore[field] = e.target.value;
@@ -73,49 +43,115 @@ class ScoresheetEntry extends React.Component {
         newScore[field] = parseInt(e.target.value);
       }
       this.setState({ scoring: newScore });
-    }
+    };
   }
 
   render() {
+    const { entry, country } = this.props;
+    const { scoring } = this.state;
+
+    const scoreSection = this.state.renderScoreSection ? (
+      <section id={`section--entry_score_${entry.id}`}>
+        <section id={`section--entry_video_${entry.id}`}>
+          <YouTube url={entry.video_url} />
+        </section>
+        <table>
+          <tbody>
+            <tr>
+              <th>Song Score</th>
+              <th>Dance Score</th>
+              <th>Costume Score</th>
+              <th>Eurocheese Score</th>
+              <th>Bonus Points</th>
+              <th>Bonus Points Comment</th>
+            </tr>
+            <tr>
+              <td>
+                <input
+                  type="number"
+                  min="0"
+                  max="12"
+                  name="song_score"
+                  onChange={this.handleChange("song_score")}
+                  value={scoring.song_score || ""}
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  min="0"
+                  max="12"
+                  name="dance_score"
+                  onChange={this.handleChange("dance_score")}
+                  value={scoring.dance_score || ""}
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  min="0"
+                  max="12"
+                  name="costume_score"
+                  onChange={this.handleChange("costume_score")}
+                  value={scoring.costume_score || ""}
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  min="0"
+                  max="12"
+                  name="cheese_score"
+                  onChange={this.handleChange("cheese_score")}
+                  value={scoring.cheese_score || ""}
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  name="bonus_points"
+                  onChange={this.handleChange("bonus_points")}
+                  value={scoring.bonus_points || ""}
+                />
+              </td>
+              <td>
+                <textarea
+                  onChange={this.handleChange("bonus_comment")}
+                  value={scoring.bonus_comment || ""}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <button>Submit Score</button>
+      </section>
+    ) : (
+      ""
+    );
+
     return (
       <ul>
-        <section className={`section--entry_parent_${this.entry.id}`}>
-          <li id={`li--entry_country`}><img src={ this.country.flag_url }/><p>{ this.country.name }</p></li>
-          <li>{ this.entry.song_title}</li>
-          <li>{ this.entry.artist}</li>
-          <li><button onClick={ () => { this.toggleScoreShow() } }>Hide/Show Scores</button></li>
+        <section className={`section--entry_parent_${entry.id}`}>
+          <li id={`li--entry_country`}>
+            <img src={country.flag_url} />
+            <p>{country.name}</p>
+          </li>
+          <li>{entry.song_title}</li>
+          <li>{entry.artist}</li>
+          <li>
+            <button
+              onClick={() => {
+                this.toggleScoreShow();
+              }}
+            >
+              Hide/Show Scores
+            </button>
+          </li>
         </section>
-        <ul>
-          <section id={`section--entry_score_${this.entry.id}`} className="hidden">
-            <section id={`section--entry_video_${this.entry.id}`}>
-              { this.renderVideo() }
-            </section>
-            <table>
-              <tbody>
-                <tr>
-                  <th>Song Score</th>
-                  <th>Dance Score</th>
-                  <th>Costume Score</th>
-                  <th>Eurocheese Score</th>
-                  <th>Bonus Points</th>
-                  <th>Bonus Points Comment</th>
-                </tr>
-                <tr>
-                  <td><input type="number" min="0" max="12" name="song_score" onChange={ this.handleChange("song_score") } value={ this.scoring.song_score || "" }/></td>
-                  <td><input type="number" min="0" max="12" name="dance_score" onChange={ this.handleChange("dance_score") } value={ this.scoring.dance_score || "" }/></td>
-                  <td><input type="number" min="0" max="12" name="costume_score" onChange={ this.handleChange("costume_score") } value={ this.scoring.costume_score || "" }/></td>
-                  <td><input type="number" min="0" max="12" name="cheese_score" onChange={ this.handleChange("cheese_score") } value={ this.scoring.cheese_score || "" }/></td>
-                  <td><input type="number" name="bonus_points" onChange={ this.handleChange("bonus_points") } value={ this.scoring.bonus_points || "" }/></td>
-                  <td><textarea onChange={ this.handleChange("bonus_comment") } value={this.scoring.bonus_comment || "" }></textarea></td>
-                </tr>
-              </tbody>
-            </table>
-            <button>Submit Score</button>
-          </section>
-        </ul>
+        <ul>{scoreSection}</ul>
       </ul>
     );
   }
 }
 
-export default connect(mapStateToProps, null)(ScoresheetEntry);
+export default ScoresheetEntry;

--- a/src/components/scoresheets/scoresheet_entry.jsx
+++ b/src/components/scoresheets/scoresheet_entry.jsx
@@ -21,6 +21,7 @@ const mapStateToProps = (state, ownProps) => {
 class ScoresheetEntry extends React.Component {
   static defaultProps = {
     scoring: {
+      id: null,
       bonus_comment: "",
       bonus_points: "",
       cheese_score: "",

--- a/src/components/scoresheets/scoresheet_entry.jsx
+++ b/src/components/scoresheets/scoresheet_entry.jsx
@@ -43,7 +43,7 @@ class ScoresheetEntry extends React.Component {
     return (
       <ul>
         <section className={`section--entry_parent_${this.props.entry.id}`}>
-          <li>{ this.props.country.name }</li>
+          <li id={`li--entry_country`}><img src={ this.props.country.flag_url }/><p>{ this.props.country.name }</p></li>
           <li>{ this.props.entry.song_title}</li>
           <li>{ this.props.entry.artist}</li>
           <li><button onClick={ () => { this.toggleScoreShow() } }>Hide/Show Scores</button></li>

--- a/src/components/scoresheets/scoresheet_entry.jsx
+++ b/src/components/scoresheets/scoresheet_entry.jsx
@@ -21,23 +21,29 @@ const mapStateToProps = (state, ownProps) => {
 class ScoresheetEntry extends React.Component {
   static defaultProps = {
     scoring: {
-      bonus_comment: null,
-      bonus_points: null,
-      cheese_score: null,
-      costume_score: null,
-      dance_score: null,
-      score_note: null,
-      song_score: null,
+      bonus_comment: "",
+      bonus_points: "",
+      cheese_score: "",
+      costume_score: "",
+      dance_score: "",
+      score_note: "",
+      song_score: "",
     }
   }
 
   constructor(props) {
     super(props);
     this.state = { renderVideo: false };
+    this.entry = this.props.entry;
+    this.country = this.props.country;
+    this.state = { scoring: this.props.scoring };
+    this.state.scoring.entry_id = this.props.entry.id || null;
+    this.state.scoring.scoresheet_id = this.props.scoresheetId || null;
+    this.scoring = this.state.scoring;
   }
 
   toggleScoreShow() {
-    let el = document.getElementById(`section--entry_score_${this.props.entry.id}`);
+    let el = document.getElementById(`section--entry_score_${this.entry.id}`);
     if (el.classList.contains("hidden")) {
       el.classList.remove("hidden");
       this.setState( { renderVideo: true } );
@@ -50,25 +56,37 @@ class ScoresheetEntry extends React.Component {
   renderVideo() {
     if (this.state.renderVideo === true) {
         return(
-          <YouTube url={this.props.entry.video_url} />
+          <YouTube url={this.entry.video_url} />
         );
     } else {
       return null;
     }
   }
 
+  handleChange(field) {
+    return (e) => {
+      let newScore = this.state.scoring;
+      if (field === "bonus_comment" || field === "score_note") {
+        newScore[field] = e.target.value;
+      } else {
+        newScore[field] = parseInt(e.target.value);
+      }
+      this.setState({ scoring: newScore });
+    }
+  }
+
   render() {
     return (
       <ul>
-        <section className={`section--entry_parent_${this.props.entry.id}`}>
-          <li id={`li--entry_country`}><img src={ this.props.country.flag_url }/><p>{ this.props.country.name }</p></li>
-          <li>{ this.props.entry.song_title}</li>
-          <li>{ this.props.entry.artist}</li>
+        <section className={`section--entry_parent_${this.entry.id}`}>
+          <li id={`li--entry_country`}><img src={ this.country.flag_url }/><p>{ this.country.name }</p></li>
+          <li>{ this.entry.song_title}</li>
+          <li>{ this.entry.artist}</li>
           <li><button onClick={ () => { this.toggleScoreShow() } }>Hide/Show Scores</button></li>
         </section>
         <ul>
-          <section id={`section--entry_score_${this.props.entry.id}`} className="hidden">
-            <section id={`section--entry_video_${this.props.entry.id}`}>
+          <section id={`section--entry_score_${this.entry.id}`} className="hidden">
+            <section id={`section--entry_video_${this.entry.id}`}>
               { this.renderVideo() }
             </section>
             <table>
@@ -79,16 +97,19 @@ class ScoresheetEntry extends React.Component {
                   <th>Costume Score</th>
                   <th>Eurocheese Score</th>
                   <th>Bonus Points</th>
+                  <th>Bonus Points Comment</th>
                 </tr>
                 <tr>
-                  <td>{ this.props.scoring.song_score }</td>
-                  <td>{ this.props.scoring.dance_score }</td>
-                  <td>{ this.props.scoring.costume_score }</td>
-                  <td>{ this.props.scoring.cheese_score }</td>
-                  <td>{ this.props.scoring.bonus_points }</td>
+                  <td><input type="number" min="0" max="12" name="song_score" onChange={ this.handleChange("song_score") } value={ this.scoring.song_score || "" }/></td>
+                  <td><input type="number" min="0" max="12" name="dance_score" onChange={ this.handleChange("dance_score") } value={ this.scoring.dance_score || "" }/></td>
+                  <td><input type="number" min="0" max="12" name="costume_score" onChange={ this.handleChange("costume_score") } value={ this.scoring.costume_score || "" }/></td>
+                  <td><input type="number" min="0" max="12" name="cheese_score" onChange={ this.handleChange("cheese_score") } value={ this.scoring.cheese_score || "" }/></td>
+                  <td><input type="number" name="bonus_points" onChange={ this.handleChange("bonus_points") } value={ this.scoring.bonus_points || "" }/></td>
+                  <td><textarea onChange={ this.handleChange("bonus_comment") } value={this.scoring.bonus_comment || "" }></textarea></td>
                 </tr>
               </tbody>
             </table>
+            <button>Submit Score</button>
           </section>
         </ul>
       </ul>

--- a/src/components/scoresheets/scoresheet_entry.jsx
+++ b/src/components/scoresheets/scoresheet_entry.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import YouTube from '../video/YouTube';
 import './scoresheet_entry.css';
 
 //=========================================
@@ -30,12 +31,29 @@ class ScoresheetEntry extends React.Component {
     }
   }
 
+  constructor(props) {
+    super(props);
+    this.state = { renderVideo: false };
+  }
+
   toggleScoreShow() {
     let el = document.getElementById(`section--entry_score_${this.props.entry.id}`);
     if (el.classList.contains("hidden")) {
       el.classList.remove("hidden");
+      this.setState( { renderVideo: true } );
     } else {
       el.classList.add("hidden");
+      this.setState( { renderVideo: false } );
+    }
+  }
+
+  renderVideo() {
+    if (this.state.renderVideo === true) {
+        return(
+          <YouTube url={this.props.entry.video_url} />
+        );
+    } else {
+      return null;
     }
   }
 
@@ -50,6 +68,9 @@ class ScoresheetEntry extends React.Component {
         </section>
         <ul>
           <section id={`section--entry_score_${this.props.entry.id}`} className="hidden">
+            <section id={`section--entry_video_${this.props.entry.id}`}>
+              { this.renderVideo() }
+            </section>
             <table>
               <tbody>
                 <tr>

--- a/src/components/scoresheets/scoresheets.jsx
+++ b/src/components/scoresheets/scoresheets.jsx
@@ -1,26 +1,25 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Scoresheet from './scoresheet';
-import './scoresheets.css';
+import React from "react";
+import PropTypes from "prop-types";
+import Scoresheet from "./scoresheet";
+import "./scoresheets.css";
 
 //=========================================
 // component
 
 export default class Scoresheets extends React.Component {
-
   static propTypes = {
-    scoresheets: PropTypes.array.isRequired,
-  }
+    scoresheets: PropTypes.array.isRequired
+  };
 
   static defaultProps = {
     scoresheets: []
-  }
+  };
 
   constructor(props) {
     super(props);
     this.state = {
-      scoresheet: props.scoresheets[0],
-    }
+      scoresheet: props.scoresheets[0]
+    };
   }
 
   componentDidMount() {
@@ -35,40 +34,41 @@ export default class Scoresheets extends React.Component {
     }
     if (newProps.scoresheets !== this.props.scoresheets) {
       if (!this.state.scoresheet && newProps.scoresheets[0]) {
-        this.setState({ scoresheet: newProps.scoresheets[0]});
+        this.setState({ scoresheet: newProps.scoresheets[0] });
       }
     }
   }
 
   scoresheetHeaders() {
     if (this.props.scoresheets.length > 0) {
-      return this.props.scoresheets.map( (scoresheet, idx) => {
+      return this.props.scoresheets.map((scoresheet, idx) => {
         if (scoresheet) {
-          return(
+          return (
             <span
               className={`span--scoresheet-nav-${scoresheet.id}`}
-              key={ scoresheet.id }
-              onClick={ () => { this.setState({ scoresheet: scoresheet}) } }>
-              { scoresheet.name }
+              key={scoresheet.id}
+              onClick={() => {
+                this.setState({ scoresheet: scoresheet });
+              }}
+            >
+              {scoresheet.name}
             </span>
-          )
+          );
         } else {
-          return <span key={idx} >Loading...</span>
+          return <span key={idx}>Loading...</span>;
         }
       });
     }
   }
 
   render() {
-    return(
+    return (
       <section className="section--scoresheets_container">
-        <nav className="nav--scoresheets_nav">
-          { this.scoresheetHeaders() }
-        </nav>
+        <nav className="nav--scoresheets_nav">{this.scoresheetHeaders()}</nav>
         <section className="section--scoresheet_show">
-            <Scoresheet scoresheet={ this.state.scoresheet }/>
+          <Scoresheet scoresheet={this.state.scoresheet} />
         </section>
       </section>
-    )
+    );
   }
 }

--- a/src/components/scoresheets/scoresheets.jsx
+++ b/src/components/scoresheets/scoresheets.jsx
@@ -13,10 +13,14 @@ export default class Scoresheets extends React.Component {
   }
 
   static defaultProps = {
+    scoresheets: []
   }
 
   constructor(props) {
     super(props);
+    this.state = {
+      scoresheet: props.scoresheets[0],
+    }
   }
 
   componentDidMount() {
@@ -29,6 +33,11 @@ export default class Scoresheets extends React.Component {
     if (!this.props.user && newProps.user) {
       newProps.fetchScoresheets(newProps.user.id);
     }
+    if (newProps.scoresheets !== this.props.scoresheets) {
+      if (!this.state.scoresheet && newProps.scoresheets[0]) {
+        this.setState({ scoresheet: newProps.scoresheets[0]});
+      }
+    }
   }
 
   scoresheetHeaders() {
@@ -36,7 +45,12 @@ export default class Scoresheets extends React.Component {
       return this.props.scoresheets.map( (scoresheet, idx) => {
         if (scoresheet) {
           return(
-            <span className={`span--scoresheet-nav-${scoresheet.id}`} key={ scoresheet.id }>{ scoresheet.name }</span>
+            <span
+              className={`span--scoresheet-nav-${scoresheet.id}`}
+              key={ scoresheet.id }
+              onClick={ () => { this.setState({ scoresheet: scoresheet}) } }>
+              { scoresheet.name }
+            </span>
           )
         } else {
           return <span key={idx} >Loading...</span>
@@ -52,7 +66,7 @@ export default class Scoresheets extends React.Component {
           { this.scoresheetHeaders() }
         </nav>
         <section className="section--scoresheet_show">
-            <Scoresheet scoresheet={ Object.values(this.props.scoresheets)[0] }/>
+            <Scoresheet scoresheet={ this.state.scoresheet }/>
         </section>
       </section>
     )

--- a/src/components/scoresheets/scoresheets_container.jsx
+++ b/src/components/scoresheets/scoresheets_container.jsx
@@ -1,15 +1,19 @@
-import { connect } from 'react-redux';
-import Scoresheets from './scoresheets';
-import { fetchScoresheet, fetchScoresheets, removeScoresheet } from '../../actions/scoresheet_actions';
+import { connect } from "react-redux";
+import Scoresheets from "./scoresheets";
+import {
+  fetchScoresheet,
+  fetchScoresheets,
+  removeScoresheet
+} from "../../actions/scoresheet_actions";
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
-    scoresheets: state.scoresheets,
-  }
+    scoresheets: state.scoresheets
+  };
 };
 
-const mapDispatchToProps = (dispatch) => ({
-  fetchScoresheets: (userId) => dispatch(fetchScoresheets(userId)),
+const mapDispatchToProps = dispatch => ({
+  fetchScoresheets: userId => dispatch(fetchScoresheets(userId))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Scoresheets);

--- a/src/components/video/YouTube.jsx
+++ b/src/components/video/YouTube.jsx
@@ -12,9 +12,9 @@ class YouTube extends React.Component {
         width={width}
         height={height}
         src={`https://www.youtube.com/embed/${url}?rel=0&amp;showinfo=0`}
-        frameborder="0"
+        frameBorder="0"
         allow="autoplay; encrypted-media"
-        allowfullscreen
+        allowFullScreen
       />
     );
   }

--- a/src/reducers/entries_reducers.js
+++ b/src/reducers/entries_reducers.js
@@ -10,7 +10,9 @@ const entriesReducer = (state = {}, action) => {
       newState = merge({}, state, action.payload.entries);
       return newState;
     case RECEIVE_SCORESHEET:
-      newState = merge({}, action.payload.entries);
+      Object.keys(action.payload.entries).forEach(entryId => {
+        newState[entryId] = action.payload.entries[entryId];
+      });
       return newState;
     case RECEIVE_ENTRY:
       const { entry } = action.payload;

--- a/src/reducers/entries_reducers.js
+++ b/src/reducers/entries_reducers.js
@@ -10,9 +10,7 @@ const entriesReducer = (state = {}, action) => {
       newState = merge({}, state, action.payload.entries);
       return newState;
     case RECEIVE_SCORESHEET:
-      Object.keys(action.payload.entries).forEach(entryId => {
-        newState[entryId] = action.payload.entries[entryId];
-      });
+      newState = merge({}, state, action.payload.entries);
       return newState;
     case RECEIVE_ENTRY:
       const { entry } = action.payload;

--- a/src/reducers/entries_reducers.js
+++ b/src/reducers/entries_reducers.js
@@ -10,7 +10,7 @@ const entriesReducer = (state = {}, action) => {
       newState = merge({}, state, action.payload.entries);
       return newState;
     case RECEIVE_SCORESHEET:
-      newState = merge({}, state, action.payload.entries);
+      newState = merge({}, action.payload.entries);
       return newState;
     case RECEIVE_ENTRY:
       const { entry } = action.payload;


### PR DESCRIPTION
Adds a few things:
- Clicking on a scoresheet "tab" title will switch the scoresheet view to that scoresheet. Since there's only one contest currently, this doesn't look very different, but you can check scores to verify.
- Refactors entriesReducer because merge was keeping scorings for the wrong scoresheet if there was no new score. A new scoresheet thus needs to "clear" the previous entries; we can revisit this if we feel keeping entries is important for caching.
- Adds flags to scoresheet entries. Varying flag sizes is an issue for display. Might also be worth researching smaller/less memory intensive flag images.
- Hide/show button conditionally renders video.
- Adds basic form components for scores. Currently no submit function tied to scores.