### PR TITLE
Adds spinner to all current views that have loading phases

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -41,6 +41,7 @@ ul, li {
   justify-content: center;
 }
 
+
 .div--spinnerModal {
   background: linear-gradient(to bottom right, #ffffe8, #b5c9f2);
   position: absolute;

--- a/src/components/contests/contestShow.jsx
+++ b/src/components/contests/contestShow.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { fetchContest } from "../../actions/contest_actions";
+import { startSpinner, endSpinner } from "../../actions/uiActions";
 import { withRouter, Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import "./contestShow.css";
@@ -15,7 +16,14 @@ class ContestShow extends React.Component {
       this.props.contest.year === "LOADING" ||
       this.props.entries.include(undefined)
     ) {
+      this.props.startSpinner();
       this.props.fetchContest(this.props.year);
+    }
+  }
+
+  componentWillReceiveProps() {
+    if (this.props.isSpinning) {
+      this.props.endSpinner();
     }
   }
 
@@ -71,7 +79,10 @@ ContestShow.propTypes = {
   year: PropTypes.string.isRequired,
   contest: PropTypes.object,
   entries: PropTypes.array,
-  fetchContest: PropTypes.func.isRequired
+  fetchContest: PropTypes.func.isRequired,
+  startSpinner: PropTypes.func.isRequired,
+  endSpinner: PropTypes.func.isRequired,
+  isSpinning: PropTypes.bool.isRequired
 };
 
 ContestShow.defaultProps = {
@@ -86,11 +97,14 @@ const mapStateToProps = (state, ownProps) => {
   const entries = contest.entry_ids.map(id => {
     return state.entries[id];
   });
-  return { year, contest, entries, countries };
+  const isSpinning = state.ui.spinner;
+  return { year, contest, entries, countries, isSpinning };
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  fetchContest: year => dispatch(fetchContest(year))
+  fetchContest: year => dispatch(fetchContest(year)),
+  startSpinner: () => dispatch(startSpinner()),
+  endSpinner: () => dispatch(endSpinner())
 });
 
 export default withRouter(

--- a/src/components/entries/entryShow.jsx
+++ b/src/components/entries/entryShow.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { withRouter, Link } from "react-router-dom";
 import { fetchEntry } from "../../actions/entryActions";
+import { startSpinner, endSpinner } from "../../actions/uiActions";
 import YouTube from "../video/YouTube";
 import BackArrow from "../../assets/001-back.png";
 import NextArrow from "../../assets/002-next.png";
@@ -11,13 +12,22 @@ import "./entryShow.css";
 class EntryShow extends React.Component {
   componentDidMount() {
     if (this.props.entry.song_title === "LOADING") {
+      this.props.startSpinner();
       this.props.fetchEntry(this.props.entryId);
     }
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.entry.song_title === "LOADING") {
+      if (!this.props.isSpinning) {
+        this.props.startSpinner();
+      }
       this.props.fetchEntry(nextProps.entryId);
+    } else if (
+      this.props.isSpinning &&
+      nextProps.entry.song_title !== "LOADING"
+    ) {
+      this.props.endSpinner();
     }
   }
 
@@ -45,7 +55,7 @@ class EntryShow extends React.Component {
           <article className="article--countryName">
             <img alt="country-flag" src={country.flag_url} />
             {country.name}, {contest.year}
-            <br></br>
+            <br />
             <p className="p--songDetails">
               {entry.song_title}, {entry.artist}
             </p>
@@ -70,7 +80,10 @@ EntryShow.propTypes = {
   entryId: PropTypes.string.isRequired,
   entry: PropTypes.object,
   country: PropTypes.object,
-  contest: PropTypes.object
+  contest: PropTypes.object,
+  startSpinner: PropTypes.func.isRequired,
+  endSpinner: PropTypes.func.isRequired,
+  isSpinning: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -85,16 +98,21 @@ const mapStateToProps = (state, ownProps) => {
     flag_url: "/defaultflag"
   };
 
+  const isSpinning = state.ui.spinner;
+
   return {
     entryId,
     entry,
     country,
-    contest
+    contest,
+    isSpinning
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  fetchEntry: id => dispatch(fetchEntry(id))
+  fetchEntry: id => dispatch(fetchEntry(id)),
+  startSpinner: () => dispatch(startSpinner()),
+  endSpinner: () => dispatch(endSpinner())
 });
 
 export default withRouter(

--- a/src/components/entries/entryShow.jsx
+++ b/src/components/entries/entryShow.jsx
@@ -33,7 +33,6 @@ class EntryShow extends React.Component {
 
   render() {
     const { entry, country, contest, entryId } = this.props;
-    debugger;
     let prevEntryId = parseInt(entryId) - 1;
     if (contest && !contest.entry_ids.includes(prevEntryId)) {
       prevEntryId = contest.entry_ids[contest.entry_ids.length - 1];

--- a/src/components/scoresheets/scoresheet.jsx
+++ b/src/components/scoresheets/scoresheet.jsx
@@ -4,6 +4,7 @@ import {
   fetchScoresheet,
   removeScoresheet
 } from "../../actions/scoresheet_actions";
+import { startSpinner, endSpinner } from "../../actions/uiActions";
 import ScoresheetEntry from "./scoresheet_entry.jsx";
 import "./scoresheet.css";
 
@@ -21,7 +22,7 @@ const mapStateToProps = (state, ownProps) => {
     entries[id] = state.entries[id];
   });
   const scorings = {};
-
+  const isSpinning = state.ui.spinner;
   scoresheet.scoring_ids.forEach(id => {
     if (state.scorings[id]) {
       const newScoring = state.scorings[id];
@@ -30,27 +31,40 @@ const mapStateToProps = (state, ownProps) => {
   }) || [];
 
   const countries = state.countries;
-  return { scoresheet, entries, scorings, countries };
+  return { scoresheet, entries, scorings, countries, isSpinning };
 };
 
 const mapDispatchToProps = dispatch => ({
   fetchScoresheet: scoresheetId => dispatch(fetchScoresheet(scoresheetId)),
-  removeScoresheet: scoresheetId => dispatch(removeScoresheet(scoresheetId))
+  removeScoresheet: scoresheetId => dispatch(removeScoresheet(scoresheetId)),
+  startSpinner: () => dispatch(startSpinner()),
+  endSpinner: () => dispatch(endSpinner())
 });
 
 //=========================================
 // component
 
 class Scoresheet extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = { renderBonusPoints: false };
   }
 
+  componentDidMount() {
+    if (this.props.scoresheet.id === "LOADING") {
+      this.props.startSpinner();
+    }
+  }
+
   componentWillReceiveProps(newProps) {
     if (newProps.scoresheet.id !== this.props.scoresheet.id) {
+      this.props.startSpinner();
       this.props.fetchScoresheet(newProps.scoresheet.id);
+    } else if (
+      this.props.isSpinning &&
+      this.props.scoresheet.id !== "LOADING"
+    ) {
+      this.props.endSpinner();
     }
   }
 
@@ -97,7 +111,16 @@ class Scoresheet extends React.Component {
               <th>Country</th>
               <th>Song Title</th>
               <th>Song Artist</th>
-              <th><p>Your Total Score</p><br/><label>Add Bonus Points?<input type="checkbox" onChange={ () => this.toggleBonusPoints() }/></label></th>
+              <th>
+                <p>Your Total Score</p>
+                <br />
+                <label>
+                  Add Bonus Points?<input
+                    type="checkbox"
+                    onChange={() => this.toggleBonusPoints()}
+                  />
+                </label>
+              </th>
             </tr>
           </tbody>
         </table>

--- a/src/components/userProfile/userProfile.jsx
+++ b/src/components/userProfile/userProfile.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { fetchUser } from "../../actions/userActions";
+import { startSpinner, endSpinner } from "../../actions/uiActions";
 import "./userProfile.css";
 
 class UserProfile extends React.Component {
@@ -26,7 +27,14 @@ class UserProfile extends React.Component {
 
   componentDidMount() {
     if (this.props.user.username === "LOADING...") {
+      this.props.startSpinner();
       this.props.fetchUser(this.props.userId);
+    }
+  }
+
+  componentWillReceiveProps() {
+    if (this.props.isSpinning && this.props.user.username !== "LOADING...") {
+      this.props.endSpinner();
     }
   }
 
@@ -51,14 +59,18 @@ class UserProfile extends React.Component {
 
 const mapStateToProps = (state, ownProps) => {
   const userId = ownProps.match.params.id;
+  const isSpinning = state.ui.spinner;
   return {
     user: state.users[ownProps.match.params.id],
-    userId
+    userId,
+    isSpinning
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  fetchUser: id => dispatch(fetchUser(id))
+  fetchUser: id => dispatch(fetchUser(id)),
+  startSpinner: () => dispatch(startSpinner()),
+  endSpinner: () => dispatch(endSpinner())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserProfile);


### PR DESCRIPTION
Added our global spinner to loading phases of entry show, contest show, scoresheets, and user profile pages. In the future, adding the spinner is pretty straightforward, just follow my implementation in these components!